### PR TITLE
Update Get-ADCVServerConfig.ps1

### DIFF
--- a/Get-ADCVServerConfig.ps1
+++ b/Get-ADCVServerConfig.ps1
@@ -16,9 +16,9 @@ param (
     # If you intend to batch import to NetScaler, then no spaces or capital letters in the file name.
     # If set to "screen", then output will go to screen.
     # If set to "", then the script will prompt for a file. Clicking cancel will output to the screen.
-    #[string]$outputFile = "",
+    [string]$outputFile = "",
     #[string]$outputFile = "screen",
-    [string]$outputFile = "$env:userprofile\Downloads\nsconfig.conf",
+    #[string]$outputFile = "$env:userprofile\Downloads\nsconfig.conf",
     #[string]$outputFile = "$env:HOME/Downloads/nsconfig.conf",
 
     # Optional text editor to open saved output file - text editor should handle UNIX line endings (e.g. Wordpad or Notepad++)
@@ -82,6 +82,7 @@ Function Get-OutputFile($initialDirectory)
             $DefaultLocation = 'default location "'+$initialDirectory+'"'
         }
         $filename = (('set theName to POSIX path of (choose file name '+$($DefaultName)+' '+$($DefaultLocation)+' with prompt "Save NetScaler documentation file as")' | osascript -s s) -split '"')[1]
+        $filename
     }else{
         [System.Reflection.Assembly]::LoadWithPartialName("System.windows.forms") | Out-Null
         $SaveFileDialog = New-Object System.Windows.Forms.SaveFileDialog

--- a/Get-ADCVServerConfig.ps1
+++ b/Get-ADCVServerConfig.ps1
@@ -31,6 +31,7 @@ param (
 
 # Change Log
 # ----------
+# 2018 Nov 16 - support for MacOS popups for nsconf and saveas. Switch for sort to Sort-object to support MacOs & Powershell core 6
 # 2018 Nov 5 - check text editor existince (h/t Bjørn-Kåre Flister)
 # 2018 Nov 5 - switch to extract CS vServer for selected LB/VPN/AAA vServer (h/t Bjørn-Kåre Flister)
 # 2018 Sep 19 - fixed SAML Policy and SAML Action

--- a/Get-ADCVServerConfig.ps1
+++ b/Get-ADCVServerConfig.ps1
@@ -469,7 +469,7 @@ do {
             $promptString = "Select one or more of the following Virtual Servers for configuration extraction:`n`n"
             $promptString += "Virtual Server Filter = $vserver`n`n"
             $promptString += "   Num   Type        VIP          Name`n"
-            $maxLength = ($vservers | sort length -desc | select -first 1).length
+            $maxLength = ($vservers | Sort-Object length -desc | select -first 1).length
             $promptString += "  -----  ----  " + ("-" * 15) + "  " + ("-" * $maxLength) + "`n"
             write-host $promptString
             foreach ($vserverOption in $vservers) {
@@ -612,7 +612,7 @@ if ($nsObjects."cs vserver") {
             addNSObject "cs vserver" ($backupVServers)
             $nsObjects."cs vserver" += $currentVServers
         }
-        addNSObject "lb vserver" (getNSObjects $vserverconfig "lb vserver" "-targetLBVserver")2
+        addNSObject "lb vserver" (getNSObjects $vserverconfig "lb vserver" "-targetLBVserver")
     }
 }
 
@@ -1988,7 +1988,7 @@ if ($NSObjects."stream identifier") {
 
 #cls
 "`nExtracted Objects"
-$NSObjects.GetEnumerator() | sort -Property Name
+$NSObjects.GetEnumerator() | Sort-Object -Property Name
 
 write-host "`nBuilding Config...`n
 "


### PR DESCRIPTION
line 472: changed sort to Sort-Object for Powershell Core 6.x and macos
orig:$maxLength = ($vservers | sort length -desc | select -first 1).length
new:$maxLength = ($vservers | Sort-Object length -desc | select -first 1).length

line 615: a number 2 after the last space - an error or is it supposed to be there?
orig:addNSObject "lb vserver" (getNSObjects $vserverconfig "lb vserver" "-targetLBVserver")2
new:addNSObject "lb vserver" (getNSObjects $vserverconfig "lb vserver" "-targetLBVserver")

line 1991: changed sort to Sort-Object for Powershell Core 6.x and macos
orig:$NSObjects.GetEnumerator() | sort -Property Name
new:$NSObjects.GetEnumerator() | Sort-Object -Property Name